### PR TITLE
Refactor api tests.

### DIFF
--- a/src/RecipeBook.Contracts/Responses/RecipesResponse.cs
+++ b/src/RecipeBook.Contracts/Responses/RecipesResponse.cs
@@ -1,6 +1,0 @@
-﻿namespace RecipeBook.Contracts.Responses;
-
-public record RecipesResponse
-{
-    public required IEnumerable<RecipeResponse> Recipes { get; init; } = [];
-}

--- a/test/RecipeBook.ApiService.Tests/Mother.cs
+++ b/test/RecipeBook.ApiService.Tests/Mother.cs
@@ -39,7 +39,7 @@ public static class Mother
         IEnumerable<string>? directions = default)
     {
         var recipeFaker = new Faker<UpdateRecipeRequest>()
-            .RuleFor(x => x.Id, f => id ?? ObjectId.GenerateNewId().ToString())
+            .RuleFor(x => x.Id, _ => id ?? ObjectId.GenerateNewId().ToString())
             .RuleFor(x => x.Title, f => title ?? f.Lorem.Sentence(3))
             .RuleFor(x => x.Description, f => description ?? f.Lorem.Sentence(10))
             .RuleFor(x => x.Ingredients, f => ingredients ?? f.Make(6, () => f.Lorem.Sentence(3)))

--- a/test/RecipeBook.ApiService.Tests/RecipeBookApiTests.cs
+++ b/test/RecipeBook.ApiService.Tests/RecipeBookApiTests.cs
@@ -13,17 +13,17 @@ namespace RecipeBook.ApiService.Tests;
 
 public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<RecipeBookApiFactory>, IAsyncLifetime
 {
+    private readonly HttpClient _client = factory.CreateClient();
     private readonly List<string> _createdRecipeIds = [];
 
     [Fact]
     public async Task CreateRecipe_WhenRecipeIsValid_ShouldCreateRecipe()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var request = Mother.GenerateCreateRecipeRequest();
 
         // Act
-        var response = await client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
+        var response = await _client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -42,7 +42,6 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task CreateRecipe_WhenRecipeTitleIsInValid_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
         {
             { "Title", ["'Title' must not be empty."] }
@@ -50,7 +49,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateCreateRecipeRequest(title: "");
 
         // Act
-        var response = await client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
+        var response = await _client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -63,7 +62,6 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task CreateRecipe_WhenRecipeDescriptionIsInValid_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
         {
             { "Description", ["'Description' must not be empty."] }
@@ -71,7 +69,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateCreateRecipeRequest(description: "");
 
         // Act
-        var response = await client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
+        var response = await _client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -84,7 +82,6 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task CreateRecipe_WhenRecipeIngredientsAreEmpty_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
         {
             { "Ingredients", ["'Ingredients' must not be empty."] }
@@ -93,7 +90,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateCreateRecipeRequest(ingredients: []);
 
         // Act
-        var response = await client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
+        var response = await _client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -106,7 +103,6 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task CreateRecipe_WhenRecipeIngredientsContainAnEmptyString_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
         {
             { "Ingredients[2]", ["Ingredient at index 2 must not be empty."] }
@@ -115,7 +111,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateCreateRecipeRequest(ingredients: new[] { "oregano", "garlic", "" });
 
         // Act
-        var response = await client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
+        var response = await _client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -128,7 +124,6 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task CreateRecipe_WhenRecipeDirectionsAreEmpty_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
         {
             { "Directions", ["'Directions' must not be empty."] }
@@ -137,7 +132,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateCreateRecipeRequest(directions: []);
 
         // Act
-        var response = await client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
+        var response = await _client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -150,7 +145,6 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task CreateRecipe_WhenRecipeDirectionsContainAnEmptyString_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
         {
             { "Directions[1]", ["Direction at index 1 must not be empty."] }
@@ -159,7 +153,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateCreateRecipeRequest(directions: new[] { "mix things", "", "cook things" });
 
         // Act
-        var response = await client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
+        var response = await _client.PostAsJsonAsync($"{Mother.RecipesApiBasePath}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -172,10 +166,8 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task GetAllRecipes_WhenRecipesExist_ShouldReturnRecipes()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
-        var recipe1 = await Mother.CreateRecipeAsync(client);
-        var recipe2 = await Mother.CreateRecipeAsync(client);
+        var recipe1 = await Mother.CreateRecipeAsync(_client);
+        var recipe2 = await Mother.CreateRecipeAsync(_client);
 
         _createdRecipeIds.Add(recipe1.Id);
         _createdRecipeIds.Add(recipe2.Id);
@@ -183,7 +175,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var expected = new[] { recipe1, recipe2 };
 
         // Act
-        var response = await client.GetAsync(Mother.RecipesApiBasePath);
+        var response = await _client.GetAsync(Mother.RecipesApiBasePath);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -195,11 +187,8 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     [Fact]
     public async Task GetAllRecipes_WhenNoRecipesExist_ShouldReturnNoRecipes()
     {
-        // Arrange
-        using var client = factory.CreateClient();
-
         // Act
-        var response = await client.GetAsync(Mother.RecipesApiBasePath);
+        var response = await _client.GetAsync(Mother.RecipesApiBasePath);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -212,13 +201,11 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task GetRecipeById_WhenRecipeIsFound_ShouldReturnRecipeResponse()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
-        var expected = await Mother.CreateRecipeAsync(client);
+        var expected = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(expected.Id);
 
         // Act
-        var response = await client.GetAsync($"{Mother.RecipesApiBasePath}/{expected.Id}");
+        var response = await _client.GetAsync($"{Mother.RecipesApiBasePath}/{expected.Id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -231,11 +218,10 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task GetRecipeById_WhenRecipeDoesNotExists_ShouldReturns404NotFound()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var id = ObjectId.GenerateNewId();
 
         // Act
-        var response = await client.GetAsync($"{Mother.RecipesApiBasePath}/{id}");
+        var response = await _client.GetAsync($"{Mother.RecipesApiBasePath}/{id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -244,11 +230,8 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     [Fact]
     public async Task GetRecipeById_WhenRecipeIdIsInvalid_ShouldReturnsBadRequest()
     {
-        // Arrange
-        using var client = factory.CreateClient();
-
         // Act
-        var response = await client.GetAsync($"{Mother.RecipesApiBasePath}/yoda");
+        var response = await _client.GetAsync($"{Mother.RecipesApiBasePath}/yoda");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -258,8 +241,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeIsValid_ShouldUpdateRecipe()
     {
         // Arrange
-        using var client = factory.CreateClient();
-        var inserted = await Mother.CreateRecipeAsync(client);
+        var inserted = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(inserted.Id);
 
         var request = new UpdateRecipeRequest
@@ -272,7 +254,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         };
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{inserted.Id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{inserted.Id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -289,8 +271,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeTitleIsInValid_ShouldBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
-        var inserted = await Mother.CreateRecipeAsync(client);
+        var inserted = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(inserted.Id);
 
         var request = new UpdateRecipeRequest
@@ -308,7 +289,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         });
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{inserted.Id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{inserted.Id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -321,8 +302,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeDescriptionIsInValid_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
-        var inserted = await Mother.CreateRecipeAsync(client);
+        var inserted = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(inserted.Id);
 
         var request = new UpdateRecipeRequest
@@ -340,7 +320,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         });
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{inserted.Id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{inserted.Id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -353,12 +333,10 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeIdIsInValid_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
         var request = Mother.GenerateUpdateRecipeRequest();
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/yoda", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/yoda", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -368,13 +346,11 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeIdIsNotFound_ShouldReturnNotFound()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
         var id = ObjectId.GenerateNewId();
         var request = Mother.GenerateUpdateRecipeRequest(id: id.ToString());
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -384,9 +360,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeIngredientsAreEmpty_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
-        var created = await Mother.CreateRecipeAsync(client);
+        var created = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(created.Id);
 
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
@@ -397,7 +371,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateUpdateRecipeRequest(id: created.Id, ingredients: []);
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -410,9 +384,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeIngredientsContainAnEmptyString_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
-        var created = await Mother.CreateRecipeAsync(client);
+        var created = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(created.Id);
 
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
@@ -423,7 +395,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateUpdateRecipeRequest(id: created.Id, ingredients: ["oregano", "garlic", ""]);
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -436,9 +408,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeDirectionsAreEmpty_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
-        var created = await Mother.CreateRecipeAsync(client);
+        var created = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(created.Id);
 
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
@@ -449,7 +419,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateUpdateRecipeRequest(id: created.Id, directions: []);
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -462,9 +432,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task UpdateRecipe_WhenRecipeDirectionsContainAnEmptyString_ShouldReturnBadRequest()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
-        var created = await Mother.CreateRecipeAsync(client);
+        var created = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(created.Id);
 
         var expected = Mother.GenerateValidationProblemDetails(new Dictionary<string, string[]>
@@ -475,7 +443,7 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
         var request = Mother.GenerateUpdateRecipeRequest(id: created.Id, directions: ["mix things", "", "cook things"]);
 
         // Act
-        var response = await client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
+        var response = await _client.PutAsJsonAsync($"{Mother.RecipesApiBasePath}/{created.Id}", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -488,13 +456,11 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task DeleteRecipe_WhenRecipeExists_ShouldReturnNoContent()
     {
         // Arrange
-        using var client = factory.CreateClient();
-
-        var recipe = await Mother.CreateRecipeAsync(client);
+        var recipe = await Mother.CreateRecipeAsync(_client);
         _createdRecipeIds.Add(recipe.Id);
 
         // Act
-        var response = await client.DeleteAsync($"{Mother.RecipesApiBasePath}/{recipe.Id}");
+        var response = await _client.DeleteAsync($"{Mother.RecipesApiBasePath}/{recipe.Id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
@@ -504,11 +470,10 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     public async Task DeleteRecipe_WhenRecipeDoesNotExists_ShouldReturnNotFound()
     {
         // Arrange
-        using var client = factory.CreateClient();
         var id = ObjectId.GenerateNewId();
 
         // Act
-        var response = await client.DeleteAsync($"{Mother.RecipesApiBasePath}/{id}");
+        var response = await _client.DeleteAsync($"{Mother.RecipesApiBasePath}/{id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -517,11 +482,8 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
     [Fact]
     public async Task DeleteRecipe_WhenRecipeIdIsInvalid_ShouldReturnBadRequest()
     {
-        // Arrange
-        using var client = factory.CreateClient();
-
         // Act
-        var response = await client.DeleteAsync($"{Mother.RecipesApiBasePath}/yoda");
+        var response = await _client.DeleteAsync($"{Mother.RecipesApiBasePath}/yoda");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -531,11 +493,9 @@ public class RecipeBookApiTests(RecipeBookApiFactory factory) : IClassFixture<Re
 
     public async Task DisposeAsync()
     {
-        using var client = factory.CreateClient();
-
         foreach (string recipeId in _createdRecipeIds)
         {
-            _ = await client.DeleteAsync($"{Mother.RecipesApiBasePath}/{recipeId}");
+            _ = await _client.DeleteAsync($"{Mother.RecipesApiBasePath}/{recipeId}");
         }
     }
 }


### PR DESCRIPTION
also removes the unused RecipesResponse object.

The apu tests now share an httpclient.