### PR TITLE
Add missing map to API version

### DIFF
--- a/src/RecipeBook.Api/Recipes/CreateRecipe.cs
+++ b/src/RecipeBook.Api/Recipes/CreateRecipe.cs
@@ -42,7 +42,8 @@ public static class CreateRecipe
             .WithName(Name)
             .WithDescription(Description)
             .Accepts<CreateRecipeRequest>(false, MediaTypeNames.Application.Json)
-            .AddEndpointFilter<RequestValidationFilter<CreateRecipeRequest>>();
+            .AddEndpointFilter<RequestValidationFilter<CreateRecipeRequest>>()
+            .MapToApiVersion(1);
 
         return group;
     }

--- a/src/RecipeBook.Api/Recipes/UpdateRecipe.cs
+++ b/src/RecipeBook.Api/Recipes/UpdateRecipe.cs
@@ -49,7 +49,8 @@ public static class UpdateRecipe
             .WithName(Name)
             .WithDescription(Description)
             .Accepts<UpdateRecipeRequest>(false, MediaTypeNames.Application.Json)
-            .AddEndpointFilter<RequestValidationFilter<UpdateRecipeRequest>>();
+            .AddEndpointFilter<RequestValidationFilter<UpdateRecipeRequest>>()
+            .MapToApiVersion(1);
 
         return group;
     }


### PR DESCRIPTION
I forgot to add the call to ```.MapToApiVersion()``` on a couple endpoints.

closes #6 